### PR TITLE
Feature/externalize files from chatflow - do not save as base64 (#1976)

### DIFF
--- a/packages/components/nodes/documentloaders/Pdf/Pdf.ts
+++ b/packages/components/nodes/documentloaders/Pdf/Pdf.ts
@@ -1,6 +1,9 @@
-import { INode, INodeData, INodeParams } from '../../../src/Interface'
+import { ICommonObject, INode, INodeData, INodeParams } from '../../../src/Interface'
 import { TextSplitter } from 'langchain/text_splitter'
 import { PDFLoader } from 'langchain/document_loaders/fs/pdf'
+import { getStoragePath } from '../../../src'
+import fs from 'fs'
+import path from 'path'
 
 class Pdf_DocumentLoaders implements INode {
     label: string
@@ -68,53 +71,44 @@ class Pdf_DocumentLoaders implements INode {
         ]
     }
 
-    async init(nodeData: INodeData): Promise<any> {
+    async init(nodeData: INodeData, _: string, options: ICommonObject): Promise<any> {
         const textSplitter = nodeData.inputs?.textSplitter as TextSplitter
         const pdfFileBase64 = nodeData.inputs?.pdfFile as string
         const usage = nodeData.inputs?.usage as string
         const metadata = nodeData.inputs?.metadata
         const legacyBuild = nodeData.inputs?.legacyBuild as boolean
 
-        let alldocs = []
+        let alldocs: any[] = []
         let files: string[] = []
 
-        if (pdfFileBase64.startsWith('[') && pdfFileBase64.endsWith(']')) {
-            files = JSON.parse(pdfFileBase64)
-        } else {
-            files = [pdfFileBase64]
-        }
-
-        for (const file of files) {
-            const splitDataURI = file.split(',')
-            splitDataURI.pop()
-            const bf = Buffer.from(splitDataURI.pop() || '', 'base64')
-            if (usage === 'perFile') {
-                const loader = new PDFLoader(new Blob([bf]), {
-                    splitPages: false,
-                    pdfjs: () =>
-                        // @ts-ignore
-                        legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
-                })
-                if (textSplitter) {
-                    const docs = await loader.loadAndSplit(textSplitter)
-                    alldocs.push(...docs)
-                } else {
-                    const docs = await loader.load()
-                    alldocs.push(...docs)
-                }
+        //FILE-STORAGE::["CONTRIBUTING.md","LICENSE.md","README.md"]
+        if (pdfFileBase64.startsWith('FILE-STORAGE::')) {
+            const fileName = pdfFileBase64.replace('FILE-STORAGE::', '')
+            if (fileName.startsWith('[') && fileName.endsWith(']')) {
+                files = JSON.parse(fileName)
             } else {
-                const loader = new PDFLoader(new Blob([bf]), {
-                    pdfjs: () =>
-                        // @ts-ignore
-                        legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
-                })
-                if (textSplitter) {
-                    const docs = await loader.loadAndSplit(textSplitter)
-                    alldocs.push(...docs)
-                } else {
-                    const docs = await loader.load()
-                    alldocs.push(...docs)
-                }
+                files = [fileName]
+            }
+            const chatflowid = options.chatflowid
+
+            for (const file of files) {
+                const fileInStorage = path.join(getStoragePath(), chatflowid, file)
+                const fileData = fs.readFileSync(fileInStorage)
+                const bf = Buffer.from(fileData)
+                await this.extractDocs(usage, bf, legacyBuild, textSplitter, alldocs)
+            }
+        } else {
+            if (pdfFileBase64.startsWith('[') && pdfFileBase64.endsWith(']')) {
+                files = JSON.parse(pdfFileBase64)
+            } else {
+                files = [pdfFileBase64]
+            }
+
+            for (const file of files) {
+                const splitDataURI = file.split(',')
+                splitDataURI.pop()
+                const bf = Buffer.from(splitDataURI.pop() || '', 'base64')
+                await this.extractDocs(usage, bf, legacyBuild, textSplitter, alldocs)
             }
         }
 
@@ -135,6 +129,37 @@ class Pdf_DocumentLoaders implements INode {
         }
 
         return alldocs
+    }
+
+    private async extractDocs(usage: string, bf: Buffer, legacyBuild: boolean, textSplitter: TextSplitter, alldocs: any[]) {
+        if (usage === 'perFile') {
+            const loader = new PDFLoader(new Blob([bf]), {
+                splitPages: false,
+                pdfjs: () =>
+                    // @ts-ignore
+                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+            })
+            if (textSplitter) {
+                const docs = await loader.loadAndSplit(textSplitter)
+                alldocs.push(...docs)
+            } else {
+                const docs = await loader.load()
+                alldocs.push(...docs)
+            }
+        } else {
+            const loader = new PDFLoader(new Blob([bf]), {
+                pdfjs: () =>
+                    // @ts-ignore
+                    legacyBuild ? import('pdfjs-dist/legacy/build/pdf.js') : import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js')
+            })
+            if (textSplitter) {
+                const docs = await loader.loadAndSplit(textSplitter)
+                alldocs.push(...docs)
+            } else {
+                const docs = await loader.load()
+                alldocs.push(...docs)
+            }
+        }
     }
 }
 

--- a/packages/components/nodes/vectorstores/Vectara/Vectara.ts
+++ b/packages/components/nodes/vectorstores/Vectara/Vectara.ts
@@ -11,6 +11,9 @@ import { Document } from '@langchain/core/documents'
 import { Embeddings } from '@langchain/core/embeddings'
 import { ICommonObject, INode, INodeData, INodeOutputsValue, INodeParams, IndexingResult } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
+import { getStoragePath } from '../../../src'
+import fs from 'fs'
+import path from 'path'
 
 class Vectara_VectorStores implements INode {
     label: string
@@ -182,20 +185,37 @@ class Vectara_VectorStores implements INode {
                 }
             }
 
-            let files: string[] = []
-            if (fileBase64.startsWith('[') && fileBase64.endsWith(']')) {
-                files = JSON.parse(fileBase64)
-            } else {
-                files = [fileBase64]
-            }
-
             const vectaraFiles: VectaraFile[] = []
-            for (const file of files) {
-                const splitDataURI = file.split(',')
-                splitDataURI.pop()
-                const bf = Buffer.from(splitDataURI.pop() || '', 'base64')
-                const blob = new Blob([bf])
-                vectaraFiles.push({ blob: blob, fileName: getFileName(file) })
+            let files: string[] = []
+            if (fileBase64.startsWith('FILE-STORAGE::')) {
+                const fileName = fileBase64.replace('FILE-STORAGE::', '')
+                if (fileName.startsWith('[') && fileName.endsWith(']')) {
+                    files = JSON.parse(fileName)
+                } else {
+                    files = [fileName]
+                }
+                const chatflowid = options.chatflowid
+
+                for (const file of files) {
+                    const fileInStorage = path.join(getStoragePath(), chatflowid, file)
+                    const fileData = fs.readFileSync(fileInStorage)
+                    const blob = new Blob([fileData])
+                    vectaraFiles.push({ blob: blob, fileName: getFileName(file) })
+                }
+            } else {
+                if (fileBase64.startsWith('[') && fileBase64.endsWith(']')) {
+                    files = JSON.parse(fileBase64)
+                } else {
+                    files = [fileBase64]
+                }
+
+                for (const file of files) {
+                    const splitDataURI = file.split(',')
+                    splitDataURI.pop()
+                    const bf = Buffer.from(splitDataURI.pop() || '', 'base64')
+                    const blob = new Blob([bf])
+                    vectaraFiles.push({ blob: blob, fileName: getFileName(file) })
+                }
             }
 
             try {

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -5,7 +5,7 @@ PORT=3000
 # APIKEY_PATH=/your_api_key_path/.flowise
 # SECRETKEY_PATH=/your_api_key_path/.flowise
 # LOG_PATH=/your_log_path/.flowise/logs
-# BLOB_STORAGE_PATH=/your_database_path/.flowise/storage
+# BLOB_STORAGE_PATH=/your_storage_path/.flowise/storage
 
 # NUMBER_OF_PROXIES= 1
 

--- a/packages/server/src/utils/fileRepository.ts
+++ b/packages/server/src/utils/fileRepository.ts
@@ -1,0 +1,113 @@
+import { ChatFlow } from '../database/entities/ChatFlow'
+import path from 'path'
+import { getStoragePath } from 'flowise-components'
+import fs from 'fs'
+import { IReactFlowObject } from '../Interface'
+
+export const containsBase64File = (chatflow: ChatFlow) => {
+    const parsedFlowData: IReactFlowObject = JSON.parse(chatflow.flowData)
+    const re = new RegExp('^data.*;base64', 'i')
+    let found = false
+    const nodes = parsedFlowData.nodes
+    for (const node of nodes) {
+        if (node.data.category !== 'Document Loaders') {
+            continue
+        }
+        const inputs = node.data.inputs
+        if (inputs) {
+            const keys = Object.getOwnPropertyNames(inputs)
+            for (let i = 0; i < keys.length; i++) {
+                const input = inputs[keys[i]]
+                if (!input) {
+                    continue
+                }
+                if (typeof input !== 'string') {
+                    continue
+                }
+                if (input.startsWith('[')) {
+                    try {
+                        const files = JSON.parse(input)
+                        for (let j = 0; j < files.length; j++) {
+                            const file = files[j]
+                            if (re.test(file)) {
+                                found = true
+                                break
+                            }
+                        }
+                    } catch (e) {
+                        continue
+                    }
+                }
+                if (re.test(input)) {
+                    found = true
+                    break
+                }
+            }
+        }
+    }
+    return found
+}
+
+function addFileToStorage(file: string, chatflowid: string, fileNames: string[]) {
+    const dir = path.join(getStoragePath(), chatflowid)
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+    }
+
+    const splitDataURI = file.split(',')
+    const filename = splitDataURI.pop()?.split(':')[1] ?? ''
+    const bf = Buffer.from(splitDataURI.pop() || '', 'base64')
+
+    const filePath = path.join(dir, filename)
+    fs.writeFileSync(filePath, bf)
+    fileNames.push(filename)
+    return 'FILE-STORAGE::' + JSON.stringify(fileNames)
+}
+
+export const updateFlowDataWithFilePaths = (chatflowid: string, flowData: string) => {
+    try {
+        const parsedFlowData: IReactFlowObject = JSON.parse(flowData)
+        const re = new RegExp('^data.*;base64', 'i')
+        const nodes = parsedFlowData.nodes
+        for (let j = 0; j < nodes.length; j++) {
+            const node = nodes[j]
+            if (node.data.category !== 'Document Loaders') {
+                continue
+            }
+            if (node.data.inputs) {
+                const inputs = node.data.inputs
+                const keys = Object.getOwnPropertyNames(inputs)
+                for (let i = 0; i < keys.length; i++) {
+                    const fileNames: string[] = []
+                    const key = keys[i]
+                    const input = inputs?.[key]
+                    if (!input) {
+                        continue
+                    }
+                    if (typeof input !== 'string') {
+                        continue
+                    }
+                    if (input.startsWith('[')) {
+                        try {
+                            const files = JSON.parse(input)
+                            for (let j = 0; j < files.length; j++) {
+                                const file = files[j]
+                                if (re.test(file)) {
+                                    node.data.inputs[key] = addFileToStorage(file, chatflowid, fileNames)
+                                }
+                            }
+                        } catch (e) {
+                            continue
+                        }
+                    } else if (re.test(input)) {
+                        node.data.inputs[key] = addFileToStorage(input, chatflowid, fileNames)
+                    }
+                }
+            }
+        }
+
+        return JSON.stringify(parsedFlowData)
+    } catch (e) {
+        return ''
+    }
+}

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -243,6 +243,15 @@ export const getEndingNodes = (nodeDependencies: INodeDependencies, graph: INode
  */
 export const getFileName = (fileBase64: string): string => {
     let fileNames = []
+    if (fileBase64.startsWith('FILE-STORAGE::')) {
+        const names = fileBase64.substring(14)
+        if (names.includes('[') && names.includes(']')) {
+            const files = JSON.parse(names)
+            return files.join(', ')
+        } else {
+            return fileBase64.substring(14)
+        }
+    }
     if (fileBase64.startsWith('[') && fileBase64.endsWith(']')) {
         const files = JSON.parse(fileBase64)
         for (const file of files) {

--- a/packages/ui/src/utils/genericHelper.js
+++ b/packages/ui/src/utils/genericHelper.js
@@ -234,6 +234,15 @@ export const convertDateStringToDateObject = (dateString) => {
 
 export const getFileName = (fileBase64) => {
     let fileNames = []
+    if (fileBase64.startsWith('FILE-STORAGE::')) {
+        const names = fileBase64.substring(14)
+        if (names.includes('[') && names.includes(']')) {
+            const files = JSON.parse(names)
+            return files.join(', ')
+        } else {
+            return fileBase64.substring(14)
+        }
+    }
     if (fileBase64.startsWith('[') && fileBase64.endsWith(']')) {
         const files = JSON.parse(fileBase64)
         for (const file of files) {


### PR DESCRIPTION
* initial commit. Externalizing the file base64 string from flowData

* csv - docloader - Externalizing the file base64 string from flowData

* csv - docloader - Externalizing the file base64 string from flowData

* DocX - docloader - Externalizing the file base64 string from flowData

* Json - docloader - Externalizing the file base64 string from flowData

* Jsonlines - docloader - Externalizing the file base64 string from flowData

* PDF - docloader - Externalizing the file base64 string from flowData

* Vectara - vector store - Externalizing the file base64 string from flowData

* OpenAPIToolkit - tools - Externalizing the file base64 string from flowData

* OpenAPIChain - chain - Externalizing the file base64 string from flowData

* lint fixes

* datasource enabled - initial commit

* CSVAgent - agents - Externalizing the file base64 string from flowData

* Externalizing the file base64 string from flowData

* Externalizing the file base64 string from flowData

* add pnpm-lock.yaml

* update filerepository to add try catch

* Rename FileRepository.ts to fileRepository.ts

---------